### PR TITLE
 Add support for ignoring classes via ini array

### DIFF
--- a/Default New Promotion Screen/Config/XComPromotionUIMod.ini
+++ b/Default New Promotion Screen/Config/XComPromotionUIMod.ini
@@ -18,3 +18,7 @@ RevealAllAbilities = false
 ;Allows you to override the normal AP cost of an ability for a specific class.
 ;+ClassCustomAbilityCost= (ClassName=RM_Biotic, AbilityName=RM_Reave, AbilityCost=5)
 +ClassCustomAbilityCost= (ClassName=ExampleClassName, AbilityName=CustomAbilityName, AbilityCost=5)
+
+[NewPromotionScreenbyDefault.NewPromotionScreenByDefault_PromotionScreenListener]
+.IgnoreClassNames=UIArmory_PromotionHero
+.IgnoreClassNames=UIArmory_PromotionPsiOp

--- a/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
+++ b/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
@@ -13,7 +13,7 @@ event OnInit(UIScreen Screen)
 	local Name ClassName;
 	
 	foreach IgnoreClassNames(ClassName) { // Specific classes to ignore here so that we can do UIArmory_Promotion without ORs later
-		if (Screen.IsA(ClassName)
+		if (Screen.IsA(ClassName))
 		    return;
 	}
 	

--- a/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
+++ b/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
@@ -1,5 +1,7 @@
 class NewPromotionScreenByDefault_PromotionScreenListener extends UIScreenListener;
 
+var config array<Name> IgnoreClassNames;
+
 // This event is triggered after a screen is initialized. This is called after
 // the visuals (if any) are loaded in Flash.
 event OnInit(UIScreen Screen)
@@ -8,10 +10,16 @@ event OnInit(UIScreen Screen)
 	local UIArmory_PromotionHero CustomHeroPromotionUI;
 	local StateObjectReference UnitBeingPromoted;
 	local UIAfterAction AfterActionUI;
-			
-	if (UIArmory_Promotion(Screen) == none || UIArmory_PromotionHero(Screen) != none || UIArmory_PromotionPsiOp(Screen) != none)
-	{		
-		return;		
+	local Name ClassName;
+	
+	foreach IgnoreClassNames(ClassName) { // Specific classes to ignore here so that we can do UIArmory_Promotion without ORs later
+		if (Screen.IsA(ClassName)
+		    return;
+	}
+	
+	if (UIArmory_Promotion(Screen) == none)
+	{
+		return;
 	}
 		
 	//Don't block the tutorial

--- a/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
+++ b/Default New Promotion Screen/Src/NewPromotionScreenbyDefault/Classes/NewPromotionScreenByDefault_PromotionScreenListener.uc
@@ -1,4 +1,4 @@
-class NewPromotionScreenByDefault_PromotionScreenListener extends UIScreenListener;
+class NewPromotionScreenByDefault_PromotionScreenListener extends UIScreenListener config(PromotionUIMod);
 
 var config array<Name> IgnoreClassNames;
 


### PR DESCRIPTION
In case other mods want to add their own UIArmory_Promotion subclasses that shouldn't get replaced by the ScreenListener. Includes examples based on UIArmory_PromotionHero and UIArmory_PromotionPsiOp. Other mods could include their own XComPromotionUIMod.ini with additional class names to ignore.